### PR TITLE
can be used as a library as well

### DIFF
--- a/express-server.js
+++ b/express-server.js
@@ -2,10 +2,17 @@
 
 var express = require('express');
 var entrypoint = require('./server/index.js');
+var host, port;
 
 var app = express();
 entrypoint(app);
-var host = process.env.HOST_NAME || 'localhost';
-var port = process.env.PORT || 80;
-app.listen(port);
-console.log('Express Server listening at http://' + host + ':' + port);
+if (require.main === module) {
+  // this package is being used as an app
+  host = process.env.HOST_NAME || 'localhost';
+  port = process.env.PORT || 80;
+  app.listen(port);
+  console.log('Express Server listening at http://' + host + ':' + port);
+} else {
+  // this package is being used as a library
+  module.exports = app;
+}


### PR DESCRIPTION
Using this, someone could `require('bullet-ui')` to get the express app and wire it into their serving stack however they'd like.